### PR TITLE
Replace hardcoded __master and __ip arguments with makefile variables and preprocessor variables

### DIFF
--- a/files/move_base_app/jni/Android.mk.in
+++ b/files/move_base_app/jni/Android.mk.in
@@ -8,6 +8,15 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/include
 LOCAL_LDLIBS := -landroid
 LOCAL_STATIC_LIBRARIES := android_native_app_glue roscpp_android_ndk
 
+### Please customize these values appropriately for your ROS ecosystem
+
+ROS_MASTER_URI ?= http://192.168.1.100:11311 # defaults to environment variable if defined
+ROS_ANDROID_IP := 192.168.1.101 # MUST be device IP
+
+### End customization region
+
+LOCAL_CFLAGS := -DROS_MASTER_URI="__master:=$(ROS_MASTER_URI)" -DROS_ANDROID_IP="__ip:=$(ROS_ANDROID_IP)"
+
 include $(BUILD_SHARED_LIBRARY)
 
 $(call import-module,android/native_app_glue)

--- a/files/move_base_app/jni/src/test_move_base.cpp
+++ b/files/move_base_app/jni/src/test_move_base.cpp
@@ -16,9 +16,15 @@ void android_main(android_app *papp) {
     app_dummy();
 
     int argc = 4;
-    // TODO: don't hardcode ip addresses
-    char *argv[] = {"nothing_important" , "__master:=http://192.168.1.100:11311",
-                    "__ip:=192.168.1.101", "cmd_vel:=navigation_velocity_smoother/raw_cmd_vel"};
+
+    // TODO: handle the master uri and device IP at runtime
+#ifndef ROS_MASTER_URI
+#error ROS_MASTER_URI MUST be set in files/move_base_app/jni/Android.mk.in
+#endif
+#ifndef ROS_ANDROID_IP
+#error ROS_ANDROID_IP MUST be set in files/move_base_app/jni/Android.mk.in
+#endif
+    char *argv[] = {"nothing_important" , ROS_MASTER_URI, ROS_ANDROID_IP, "cmd_vel:=navigation_velocity_smoother/raw_cmd_vel"};
 
     for(int i = 0; i < argc; i++){
         log(argv[i]);

--- a/files/sample_app/jni/Android.mk.in
+++ b/files/sample_app/jni/Android.mk.in
@@ -8,6 +8,15 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/include
 LOCAL_LDLIBS := -landroid
 LOCAL_STATIC_LIBRARIES := android_native_app_glue roscpp_android_ndk
 
+### Please customize these values appropriately for your ROS ecosystem
+
+ROS_MASTER_URI ?= http://192.168.1.100:11311 # defaults to environment variable if defined
+ROS_ANDROID_IP := 192.168.1.101 # MUST be device IP
+
+### End customization region
+
+LOCAL_CFLAGS := -DROS_MASTER_URI="__master:=$(ROS_MASTER_URI)" -DROS_ANDROID_IP="__ip:=$(ROS_ANDROID_IP)"
+
 include $(BUILD_SHARED_LIBRARY)
 
 $(call import-module,android/native_app_glue)

--- a/files/sample_app/jni/src/test.cpp
+++ b/files/sample_app/jni/src/test.cpp
@@ -61,9 +61,15 @@ void android_main(android_app *papp) {
     app_dummy();
 
     int argc = 3;
-    // TODO: don't hardcode ip addresses
+    // TODO: handle the master uri and device IP at runtime
+#ifndef ROS_MASTER_URI
+#error ROS_MASTER_URI MUST be set in files/sample_app/jni/Android.mk.in
+#endif
+#ifndef ROS_ANDROID_IP
+#error ROS_ANDROID_IP MUST be set in files/sample_app/jni/Android.mk.in
+#endif
     // %Tag(CONF_ARGS)%
-    char *argv[] = {"nothing_important" , "__master:=http://192.168.1.100:11311", "__ip:=192.168.1.101"};
+    char *argv[] = {"nothing_important" , ROS_MASTER_URI, ROS_ANDROID_IP};
     // %EndTag(CONF_ARGS)%
     //strcpy(argv[0], 'nothing_important');
     //argv[1] = '__master:=http://10.52.90.103:11311';


### PR DESCRIPTION
There could be a centrally located makefile that both would get the value for the master URI and the ROS_IP from, but at least this is a step towards being ideal.

Eventually, the ROS_IP should probably be pulled from the java networking APIs or by parsing the output of "netcfg", and the ROS_MASTER_URI should be pulled from property storage or a chooser in the app, but at least this is more visible to people trying to experiment with roscpp_android.

I cannot yet test these changes as my build is hanging up on orocos-bfl. Will follow up once I get past that hurdle.